### PR TITLE
[FEATURE] Add garbage collection setting checking member_until field

### DIFF
--- a/packages/member-management/ext_localconf.php
+++ b/packages/member-management/ext_localconf.php
@@ -1,6 +1,7 @@
 <?php
 
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
+use TYPO3\CMS\Scheduler\Task\TableGarbageCollectionTask;
 use TYPO3Incubator\MemberManagement\Controller\MembershipController;
 
 defined('TYPO3') or die();
@@ -31,3 +32,8 @@ ExtensionUtility::configurePlugin(
 
 $GLOBALS['TYPO3_CONF_VARS']['MAIL']['templateRootPaths'][1746439249]
     = 'EXT:member_management/Resources/Private/Templates/Email/';
+
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][TableGarbageCollectionTask::class]['options']['tables']['fe_users'] = [
+    'dateField' => 'member_until',
+    'expirePeriod' => 90,
+];


### PR DESCRIPTION
Deleting members after defined days via scheduler task when member_until field is set.

For testing,
* Create scheduler task "Table garbage collection (scheduler)"
* Set "Table to clean up" to "fe_users"
* Frequency to "0 3 * * *": recurring every night an 3 am